### PR TITLE
Speed up 

### DIFF
--- a/R/godata.R
+++ b/R/godata.R
@@ -1,6 +1,6 @@
 ##' prepare GO DATA for measuring semantic similarity
 ##'
-##' 
+##'
 ##' @title godata
 ##' @param OrgDb OrgDb object
 ##' @param keytype keytype
@@ -21,10 +21,10 @@ godata <- function(OrgDb=NULL, keytype = "ENTREZID", ont, computeIC = TRUE) {
         return(new("GOSemSimDATA",
                    ont = ont))
     }
-    
+
     OrgDb <- load_OrgDb(OrgDb)
     kk <- keys(OrgDb, keytype=keytype)
-    print('preparing gene to GO mapping data...')
+    message('preparing gene to GO mapping data...')
     goAnno <- suppressMessages(
         select(OrgDb, keys=kk, keytype=keytype,
                columns=c("GO", "ONTOLOGY")))
@@ -32,10 +32,10 @@ godata <- function(OrgDb=NULL, keytype = "ENTREZID", ont, computeIC = TRUE) {
     goAnno <- goAnno[!is.na(goAnno$GO), ]
     goAnno <- goAnno[goAnno$ONTOLOGY == ont,]
     if (computeIC) {
-        print('preparing IC data...')
+        message('preparing IC data...')
         IC <- computeIC(goAnno, ont)
     }
-    
+
     res <- new("GOSemSimDATA",
                keys = kk,
                ont = ont,
@@ -55,7 +55,7 @@ godata <- function(OrgDb=NULL, keytype = "ENTREZID", ont, computeIC = TRUE) {
 ##' @name GOSemSimDATA-class
 ##' @aliases GOSemSimDATA-class
 ##'   show,GOSemSimDATA-method
-##' 
+##'
 ##' @docType class
 ##' @slot keys gene ID
 ##' @slot ont ontology
@@ -79,4 +79,4 @@ setMethod("show", signature(object = "GOSemSimDATA"),
           function(object) {
               cat("#\n# DATA for Semantic Similarity calculation ...\n#\n")
           })
-             
+

--- a/R/mclusterSim.R
+++ b/R/mclusterSim.R
@@ -31,25 +31,29 @@
 ##'  cluster3 <- c("307", "308", "317")
 ##'  clusters <- list(a=cluster1, b=cluster2, c=cluster3)
 ##'  mclusterSim(clusters, semData=d, measure="Wang")
-##' 
+##'
 mclusterSim <- function(clusters, semData, measure="Wang", drop="IEA", combine="BMA") {
     n <- length(clusters)
     cluster_gos <- list()
     for (i in 1:n) {
         cluster_gos[[i]] <- sapply(clusters[[i]], gene2GO, semData, dropCodes=drop)
     }
+
+    uniqueGO <-  unique(unlist(cluster_gos))
+    go_matrix <- mgoSim(uniqueGO, uniqueGO, semData, measure = measure, combine = NULL)
+
     scores <- matrix(NA, nrow=n, ncol=n)
     rownames(scores) <- names(clusters)
     colnames(scores) <- names(clusters)
+
     for (i in seq_along(clusters)) {
         gos1 <- unlist(cluster_gos[[i]])
         gos1 <- gos1[!is.na(gos1)]
-        for (j in 1:i) {
+        for (j in seq_len(i)) {
             gos2 <- unlist(cluster_gos[[j]])
             gos2 <- gos2[!is.na(gos2)]
             if (length(gos1) != 0 && length(gos2) !=0)
-                scores[i,j] <- mgoSim(gos1, gos2, semData, measure=measure, combine=combine)
-            if ( i != j)
+                scores[i,j] <- combineScores(go_matrix[gos1, gos2], combine=combine)
                 scores[j,i] <- scores[i,j]
         }
     }

--- a/R/mgeneSim.R
+++ b/R/mgeneSim.R
@@ -28,7 +28,7 @@
 ##'@export
 ##'@examples
 ##'
-##'     d <- godata('org.Hs.eg.db', ont="MF", computeIC=FALSE)
+##' d <- godata('org.Hs.eg.db', ont="MF", computeIC=FALSE)
 ##'	mgeneSim(c("835", "5261","241"), semData=d, measure="Wang")
 ##'
 mgeneSim <- function (genes, semData, measure="Wang", drop="IEA", combine="BMA", verbose=TRUE) {
@@ -39,24 +39,21 @@ mgeneSim <- function (genes, semData, measure="Wang", drop="IEA", combine="BMA",
     colnames(scores) <- genes
 
     gos <- lapply(genes, gene2GO, semData, dropCodes=drop)
-
+    uniqueGO <-  unique(unlist(gos))
+    go_matrix <- mgoSim(uniqueGO, uniqueGO, semData, measure = measure, combine = NULL)
     if (verbose) {
-        cnt <- 1
-        pb <- txtProgressBar(min=0, max=sum(1:n), style=3)
+      cnt <- 1
+      pb <- txtProgressBar(min=0, max=sum(1:n), style=3)
     }
     for (i in seq_along(genes)) {
-        for (j in 1:i) {
-            if (verbose) {
-                setTxtProgressBar(pb, cnt)
-                cnt <- cnt + 1
-            }
-            scores[i,j] <- mgoSim(gos[[i]], gos[[j]], semData, measure=measure,
-                                  combine=combine)
-
-            if (j != i) {
-                scores[j,i] <- scores[i,j]
-            }
+      for (j in seq_len(i)){
+        if (verbose) {
+          setTxtProgressBar(pb, cnt)
+          cnt <- cnt + 1
         }
+        scores[i,j] <- combineScores(go_matrix[gos[[i]], gos[[j]]], combine = combine)
+        scores[j,i] <- scores[i,j]
+      }
     }
     if (verbose)
         close(pb)


### PR DESCRIPTION
I improved a the speed of mgeneSim and mclusterSim by 

1. avoiding recalculating twice the same position: 
  They previously assigned  scores[i, j] to scores[j, i] but it calculate it twice, now the second loop does just one triangle.
2. Pre-calculating the GO similarity:
  They used to calculate the similarity between two go terms each time it was needed, now it calculates the similarity only once, so it speeds up the process for large comparisons. 

I also changed two prints in goData to two messages for the user.