### PR TITLE
Fix: Wang method ignores edge relationship types (all edges weighted 0.7)

### DIFF
--- a/R/WangMethod.R
+++ b/R/WangMethod.R
@@ -123,9 +123,16 @@ getSV <- function(ID, ont, rel_df, weight=NULL) {
     rel_df <- rel_df[rel_df$Ontology == ont,]
     if (! 'relationship' %in% colnames(rel_df))
         rel_df$relationship <- "other"
-    
+
+    ## GO.db emits relationship names as "isa" / "part of" (see GOBPPARENTS),
+    ## but the weight table above is keyed on "is_a" / "part_of". Without
+    ## normalising these spellings, every edge fails the match below and is
+    ## remapped to "other", so Wang similarity silently uses a uniform 0.7
+    ## weight for all edges instead of is_a = 0.8 / part_of = 0.6.
+    rel_df$relationship[rel_df$relationship %in% c("isa", "is a")] <- "is_a"
+    rel_df$relationship[rel_df$relationship %in% c("part of")]     <- "part_of"
     rel_df$relationship[!rel_df$relationship %in% c("is_a", "part_of")] <- "other"
-    
+
 
     sv <- 1
     names(sv) <- ID


### PR DESCRIPTION
## Summary

The Wang semantic similarity method silently applies a **uniform edge weight of 0.7 to every edge**, instead of the published Wang et al. (2007) weights (`is_a = 0.8`, `part_of = 0.6`). This is caused by a relationship-name spelling mismatch between `GO.db` and the weight lookup in `getSV()`.

Affects `goSim()`, `mgoSim()`, `geneSim()`, `clusterSim()` — anything with `measure = "Wang"`. IC-based measures (Lin/Resnik/Jiang/Rel) are unaffected.

Verified on GOSemSim 2.36.0 + GO.db 3.22.0.

## Root cause

`GO.db` parent maps emit relationship names with spaces and no underscores:

```r
library(GO.db)
table(unlist(lapply(as.list(GOBPPARENTS), names)))
#> isa  negatively regulates  part of  positively regulates  regulates
```

These spellings are baked into the shipped `gotbl`:

```r
library(GOSemSim)
data("gotbl", package = "GOSemSim")
table(gotbl$relationship)
#> isa: 71512   part of: 7187   regulates: 3216   ... (87,439 edges)
```

But `getSV()` keys its weight table on `"is_a"` / `"part_of"`:

```r
weight <- c(is_a = 0.8, part_of = 0.6, other = 0.7)
rel_df$relationship[!rel_df$relationship %in% c("is_a", "part_of")] <- "other"
```

Since `"isa" != "is_a"` and `"part of" != "part_of"`, **every** edge fails the membership test and is remapped to `"other"`:

```r
rel <- gotbl$relationship
rel[!rel %in% c("is_a", "part_of")] <- "other"
table(rel)
#> other: 87439     # ALL edges -> uniform 0.7
```

This is likely the underlying cause of the symptom reported in #30 (Wang scores appearing identical across BP/MF/CC).

## Fix

Normalise the `GO.db` relationship spellings to the weight-table keys before the existing membership test. `regulates` / `positively regulates` / `negatively regulates` continue to map to `"other"` (0.7), matching the existing design (Wang 2007 defines distinct weights only for `is_a` and `part_of`).

## Impact (heads-up for maintainers)

This **changes Wang output for all users** — it is a behavioural fix, not a no-op. Example (BP, `org.Hs.eg.db`), verified by patching `getSV()` in 2.36.0:

| Pair | Before (0.7 uniform) | After (0.8 / 0.6) |
|---|---|---|
| GO:0006915 / GO:0012501 | 0.812 | 0.842 |
| GO:0043065 / GO:0043068 | 0.816 | 0.847 |
| GO:0007155 / GO:0007160 | 0.717 | 0.747 |

If preserving backward compatibility is a concern, an alternative is to gate this behind a `weight` / `legacy` argument — happy to adjust the PR either way.
